### PR TITLE
フォロー関係の API の作成とリファクタ

### DIFF
--- a/internal/handler/follows.go
+++ b/internal/handler/follows.go
@@ -6,11 +6,12 @@ import (
 )
 
 func setFollowsRoutesFrom(r *gin.RouterGroup) {
-	users := r.Group("/follows")
-	users.Use(authMiddleware())
+	follows := r.Group("/follows")
+	follows.Use(authMiddleware())
 	{
-		users.PUT("/follow", models.FollowUser)
-		users.PUT("/unfollow", models.UnfollowUser)
-		users.GET("/followed", models.Followed)
+		follows.PUT("/follow", models.FollowUser)
+		follows.PUT("/unfollow", models.UnfollowUser)
+		follows.GET("/followed", models.Followed)
+		follows.PUT("/reject", models.RejectUser)
 	}
 }

--- a/internal/handler/follows.go
+++ b/internal/handler/follows.go
@@ -1,0 +1,16 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/n4mlz/sns-backend/internal/models"
+)
+
+func setFollowsRoutesFrom(r *gin.RouterGroup) {
+	users := r.Group("/follows")
+	users.Use(authMiddleware())
+	{
+		users.PUT("/follow", models.FollowUser)
+		users.PUT("/unfollow", models.UnfollowUser)
+		users.GET("/followed", models.Followed)
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -19,5 +19,6 @@ func (h *Handler) SetupRoutes() {
 	{
 		setSettingsRoutesFrom(api)
 		setUsersRoutesFrom(api)
+		setFollowsRoutesFrom(api)
 	}
 }

--- a/internal/handler/users.go
+++ b/internal/handler/users.go
@@ -9,13 +9,10 @@ func setUsersRoutesFrom(r *gin.RouterGroup) {
 	users := r.Group("/users")
 	users.Use(authMiddleware())
 	{
-		users.PUT("/follow", models.FollowUser)
-		users.PUT("/unfollow", models.UnfollowUser)
-
 		user := users.Group("/:userName")
 		{
-			user.GET("", models.GetUser)
-			user.GET("/mutuals", models.GetMutualFollow)
+			user.GET("", models.User)
+			user.GET("/mutuals", models.MutualFollow)
 		}
 	}
 }

--- a/internal/models/follows.go
+++ b/internal/models/follows.go
@@ -1,0 +1,98 @@
+package models
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/n4mlz/sns-backend/internal/repository/model"
+	"github.com/n4mlz/sns-backend/internal/repository/query"
+	"github.com/rs/xid"
+)
+
+func FollowUser(ctx *gin.Context) {
+	var request UserNameSchema
+	err := ctx.ShouldBindJSON(&request)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if !isExistUser(request.UserName) {
+		ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	fromUserId := ctx.GetString("userId")
+	toUserId := userNameToUserId(request.UserName)
+
+	if isFollowing(fromUserId, toUserId) {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "already following"})
+		return
+	}
+
+	newFollow := &model.Follow{
+		ID:              xid.New().String(),
+		FollowerUserID:  fromUserId,
+		FollowingUserID: toUserId}
+
+	query.Follow.WithContext(context.Background()).Save(newFollow)
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"followingUserName": request.UserName,
+	})
+}
+
+func UnfollowUser(ctx *gin.Context) {
+	var request UserNameSchema
+	err := ctx.ShouldBindJSON(&request)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if !isExistUser(request.UserName) {
+		ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	fromUserId := ctx.GetString("userId")
+	toUserId := userNameToUserId(request.UserName)
+
+	if !isFollowing(fromUserId, toUserId) {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "not following"})
+		return
+	}
+
+	query.Follow.WithContext(context.Background()).Where(query.Follow.FollowerUserID.Eq(fromUserId)).Where(query.Follow.FollowingUserID.Eq(toUserId)).Delete()
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"unfollowingUserName": request.UserName,
+	})
+}
+
+func Followed(ctx *gin.Context) {
+	userId := ctx.GetString("userId")
+
+	FollowRequestList, err := getFollowRequestUserIdList(userId)
+
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	FollowRequests, _ := query.User.WithContext(context.Background()).Where(query.User.ID.In(FollowRequestList...)).Find()
+
+	var response []UserDataSchema
+	for _, user := range FollowRequests {
+		response = append(response, UserDataSchema{
+			UserName:        user.UserName,
+			DisplayName:     user.DisplayName,
+			Biography:       user.Biography,
+			CreatedAt:       user.CreatedAt,
+			FollowingStatus: FOLLOWED,
+		})
+	}
+
+	ctx.JSON(http.StatusOK, response)
+}

--- a/internal/models/schema.go
+++ b/internal/models/schema.go
@@ -1,9 +1,19 @@
 package models
 
+import "time"
+
 type ProfileSchema struct {
 	UserName    string `json:"userName"`
 	DisplayName string `json:"displayName"`
 	Biography   string `json:"biography"`
+}
+
+type UserDataSchema struct {
+	UserName        string    `json:"userName"`
+	DisplayName     string    `json:"displayName"`
+	Biography       string    `json:"biography"`
+	CreatedAt       time.Time `json:"createdAt"`
+	FollowingStatus string    `json:"followingStatus"`
 }
 
 type UserNameSchema struct {

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -22,13 +22,22 @@ func SaveProfile(ctx *gin.Context) {
 		return
 	}
 
+	userId := ctx.GetString("userId")
+
 	newUser := &model.User{
-		ID:          ctx.GetString("userId"),
+		ID:          userId,
 		UserName:    request.UserName,
 		DisplayName: request.DisplayName,
 		Biography:   request.Biography}
 
 	query.User.WithContext(context.Background()).Save(newUser)
+
+	newFollow := &model.Follow{
+		ID:              userId,
+		FollowerUserID:  userId,
+		FollowingUserID: userId}
+
+	query.Follow.WithContext(context.Background()).Save(newFollow)
 
 	response := ProfileSchema{
 		UserName:    newUser.UserName,

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -26,12 +26,14 @@ func SaveProfile(ctx *gin.Context) {
 		ID:          ctx.GetString("userId"),
 		UserName:    request.UserName,
 		DisplayName: request.DisplayName,
-		Biography:   &request.Biography}
+		Biography:   request.Biography}
 
 	query.User.WithContext(context.Background()).Save(newUser)
 
-	ctx.JSON(http.StatusOK, gin.H{
-		"userName":    newUser.UserName,
-		"displayName": newUser.DisplayName,
-		"biography":   newUser.Biography})
+	response := ProfileSchema{
+		UserName:    newUser.UserName,
+		DisplayName: newUser.DisplayName,
+		Biography:   newUser.Biography}
+
+	ctx.JSON(http.StatusOK, response)
 }

--- a/internal/models/users.go
+++ b/internal/models/users.go
@@ -5,73 +5,10 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/n4mlz/sns-backend/internal/repository/model"
 	"github.com/n4mlz/sns-backend/internal/repository/query"
-	"github.com/rs/xid"
 )
 
-func FollowUser(ctx *gin.Context) {
-	var request UserNameSchema
-	err := ctx.ShouldBindJSON(&request)
-	if err != nil {
-		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	if !isExistUser(request.UserName) {
-		ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "user not found"})
-		return
-	}
-
-	fromUserId := ctx.GetString("userId")
-	toUserId := userNameToUserId(request.UserName)
-
-	if isFollowing(fromUserId, toUserId) {
-		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "already following"})
-		return
-	}
-
-	newFollow := &model.Follow{
-		ID:              xid.New().String(),
-		FollowerUserID:  fromUserId,
-		FollowingUserID: toUserId}
-
-	query.Follow.WithContext(context.Background()).Save(newFollow)
-
-	ctx.JSON(http.StatusOK, gin.H{
-		"followingUserName": request.UserName,
-	})
-}
-
-func UnfollowUser(ctx *gin.Context) {
-	var request UserNameSchema
-	err := ctx.ShouldBindJSON(&request)
-	if err != nil {
-		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	if !isExistUser(request.UserName) {
-		ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "user not found"})
-		return
-	}
-
-	fromUserId := ctx.GetString("userId")
-	toUserId := userNameToUserId(request.UserName)
-
-	if !isFollowing(fromUserId, toUserId) {
-		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "not following"})
-		return
-	}
-
-	query.Follow.WithContext(context.Background()).Where(query.Follow.FollowerUserID.Eq(fromUserId)).Where(query.Follow.FollowingUserID.Eq(toUserId)).Delete()
-
-	ctx.JSON(http.StatusOK, gin.H{
-		"unfollowingUserName": request.UserName,
-	})
-}
-
-func GetUser(ctx *gin.Context) {
+func User(ctx *gin.Context) {
 	userName := ctx.Param("userName")
 	user, err := query.User.WithContext(context.Background()).Where(query.User.UserName.Eq(userName)).Take()
 	if err != nil {
@@ -79,15 +16,18 @@ func GetUser(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{
-		"userName":    user.UserName,
-		"displayName": user.DisplayName,
-		"biography":   user.Biography,
-		"createdAt":   user.CreatedAt,
-	})
+	response := UserDataSchema{
+		UserName:        user.UserName,
+		DisplayName:     user.DisplayName,
+		Biography:       user.Biography,
+		CreatedAt:       user.CreatedAt,
+		FollowingStatus: getFollowingStatus(ctx.GetString("userId"), user.ID),
+	}
+
+	ctx.JSON(http.StatusOK, response)
 }
 
-func GetMutualFollow(ctx *gin.Context) {
+func MutualFollow(ctx *gin.Context) {
 	userName := ctx.Param("userName")
 
 	if !isExistUser(userName) {
@@ -97,21 +37,23 @@ func GetMutualFollow(ctx *gin.Context) {
 
 	userId := userNameToUserId(userName)
 
-	mutuals, err := getMutualFollowUserIdList(userId)
+	mutualList, err := getMutualFollowUserIdList(userId)
 
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	mutualUsers, _ := query.User.WithContext(context.Background()).Where(query.User.ID.In(mutuals...)).Find()
+	mutualUsers, _ := query.User.WithContext(context.Background()).Where(query.User.ID.In(mutualList...)).Find()
 
-	var response []ProfileSchema
+	var response []UserDataSchema
 	for _, user := range mutualUsers {
-		response = append(response, ProfileSchema{
-			UserName:    user.UserName,
-			DisplayName: user.DisplayName,
-			Biography:   *user.Biography,
+		response = append(response, UserDataSchema{
+			UserName:        user.UserName,
+			DisplayName:     user.DisplayName,
+			Biography:       user.Biography,
+			CreatedAt:       user.CreatedAt,
+			FollowingStatus: getFollowingStatus(ctx.GetString("userId"), user.ID),
 		})
 	}
 

--- a/internal/repository/model/users.gen.go
+++ b/internal/repository/model/users.gen.go
@@ -15,7 +15,7 @@ type User struct {
 	ID          string    `gorm:"column:id;type:varchar(100);primaryKey" json:"id"`
 	UserName    string    `gorm:"column:user_name;type:varchar(100);not null;uniqueIndex:users_unique,priority:1" json:"user_name"`
 	DisplayName string    `gorm:"column:display_name;type:varchar(100);not null" json:"display_name"`
-	Biography   *string   `gorm:"column:biography;type:text" json:"biography"`
+	Biography   string    `gorm:"column:biography;type:text;not null" json:"biography"`
 	CreatedAt   time.Time `gorm:"column:created_at;type:timestamp;not null" json:"created_at"`
 }
 

--- a/sql_init/1_ddl.sql
+++ b/sql_init/1_ddl.sql
@@ -129,7 +129,7 @@ CREATE TABLE `users` (
   `id` varchar(100) NOT NULL,
   `user_name` varchar(100) NOT NULL,
   `display_name` varchar(100) NOT NULL,
-  `biography` text DEFAULT NULL,
+  `biography` text NOT NULL,
   `created_at` timestamp NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `users_unique` (`user_name`)
@@ -145,4 +145,4 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2024-03-22  4:47:27
+-- Dump completed on 2024-03-22 15:51:28


### PR DESCRIPTION
## Summary
- follow の状態をレスポンスに含むように変更
- フォロー関係の API を `/api/user` から分離し `/api/follows` に
- 軽微な挙動の調整