### PR TITLE
API の公開範囲を変更

### DIFF
--- a/internal/interfaces/middleware.go
+++ b/internal/interfaces/middleware.go
@@ -26,6 +26,22 @@ func authMiddleware() gin.HandlerFunc {
 	}
 }
 
+func authMiddlewareNoAbort() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		authHeader := ctx.GetHeader("Authorization")
+		idToken := strings.Replace(authHeader, "Bearer ", "", 1)
+
+		token, err := validation.VerifyIDToken(ctx, idToken)
+		if err != nil {
+			ctx.Set("userId", "")
+		} else {
+			ctx.Set("userId", token.Claims["user_id"].(string))
+		}
+
+		ctx.Next()
+	}
+}
+
 func SetCors(r *gin.Engine) {
 	r.Use(cors.New(cors.Config{
 		AllowOrigins: []string{

--- a/internal/interfaces/users.go
+++ b/internal/interfaces/users.go
@@ -11,9 +11,17 @@ func setUsersRoutesFrom(r *gin.RouterGroup) {
 	{
 		user := users.Group("/:userName")
 		{
+			user.GET("/posts", usecases.UserPosts)
+		}
+	}
+
+	usersNoAuth := r.Group("/users")
+	usersNoAuth.Use(authMiddlewareNoAbort())
+	{
+		user := usersNoAuth.Group("/:userName")
+		{
 			user.GET("", usecases.User)
 			user.GET("/mutuals", usecases.MutualFollow)
-			user.GET("/posts", usecases.UserPosts)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `/api/users/{userName}` と `/api/users/{userName}/mutuals` を idToken なしでもレスポンスを返すように変更