### PR TITLE
サービスアカウントキーを Docker イメージに含めないように修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 # MariaDB data
 
 sql_data/*
+serviceAccountKey.json

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -10,7 +10,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/a
 FROM debian:12.8-slim AS prod
 
 COPY --from=build /go/bin/app /go/bin/app
-COPY serviceAccountKey.json .
 RUN apt update -y && apt-get install -y ca-certificates
 EXPOSE 8080
 

--- a/serviceAccountKey.example.json
+++ b/serviceAccountKey.example.json
@@ -1,0 +1,13 @@
+{
+  "type": "XXXX",
+  "project_id": "XXXX",
+  "private_key_id": "XXXX",
+  "private_key": "XXXX",
+  "client_email": "XXXX",
+  "client_id": "XXXX",
+  "auth_uri": "XXXX",
+  "token_uri": "XXXX",
+  "auth_provider_x509_cert_url": "XXXX",
+  "client_x509_cert_url": "XXXX",
+  "universe_domain": "XXXX"
+}


### PR DESCRIPTION
## Summary
- 本番用 Docker イメージに `serviceAccountKey.json` を含めないように変更
- サービスアカウントキーを実行時に読み込む構成に変更