### PR TITLE
fix: update go build image

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS build
+FROM golang:1.25 AS build
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
## 概要
Goの依存関係要件に合わせて本番ビルドイメージを更新します。

## 変更内容
- ビルド用Goイメージを1.23から1.25へ更新